### PR TITLE
Add dark mode toggle

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
-# Getting Started with Create React App
+# Synergy Litigation Services Website
 
-This project was bootstrapped with [Create React App](https://github.com/facebook/create-react-app).
+This project is a marketing site built with React and Bootstrap. It now includes a built in dark mode that can be toggled using the moon icon in the navigation bar.
+
+## Getting Started
+
+Run `npm start` to launch the development server. Use `npm run build` to create a production build.
 
 ## Available Scripts
 

--- a/public/index.html
+++ b/public/index.html
@@ -6,6 +6,10 @@
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="theme-color" content="#000000" />
     <meta
+      name="description"
+      content="Synergy Litigation Services provides professional court reporting and litigation support."
+    />
+    <meta
       name="Synergy Litigation Services"
       content="Synergy Litigation Services"
     />
@@ -26,7 +30,7 @@
     -->
     <title>Synergy Litigation Services</title>
   </head>
-  <body>
+  <body data-bs-theme="light">
     <noscript>You need to enable JavaScript to run this app.</noscript>
     <div id="root"></div>
     <!--

--- a/src/components/DarkModeToggle/DarkModeToggle.js
+++ b/src/components/DarkModeToggle/DarkModeToggle.js
@@ -1,0 +1,20 @@
+import { useContext } from "react";
+import { Button } from "react-bootstrap";
+import { ThemeContext } from "../../context/ThemeContext";
+import "bootstrap-icons/font/bootstrap-icons.css";
+
+const DarkModeToggle = () => {
+  const { theme, toggleTheme } = useContext(ThemeContext);
+  return (
+    <Button
+      variant="secondary"
+      onClick={toggleTheme}
+      aria-label="Toggle dark mode"
+      className="ms-2"
+    >
+      <i className={`bi ${theme === "light" ? "bi-moon-fill" : "bi-sun-fill"}`}></i>
+    </Button>
+  );
+};
+
+export default DarkModeToggle;

--- a/src/components/DarkModeToggle/index.js
+++ b/src/components/DarkModeToggle/index.js
@@ -1,0 +1,1 @@
+export { default } from './DarkModeToggle';

--- a/src/components/NavBar/NavBar.js
+++ b/src/components/NavBar/NavBar.js
@@ -1,5 +1,6 @@
 import React, { useState, useEffect } from "react";
 import { Navbar, Nav, Button, Container } from "react-bootstrap";
+import DarkModeToggle from "../DarkModeToggle";
 
 // * Style
 import "./style.css";
@@ -63,16 +64,19 @@ function NavBar() {
             <Nav.Link href="#contact">Contact Us</Nav.Link>
             <Nav.Link href="#contact">About Us</Nav.Link>
           </Nav>
-          <Button
-            variant="primary"
-            as="a"
-            href="https://synergylit.reporterbase.com/contact"
-            target="_blank"
-            rel="noreferrer noopener"
-            className="mysls"
-          >
-            Access My SLS Client Portal
-          </Button>
+          <div className="d-flex align-items-center">
+            <Button
+              variant="primary"
+              as="a"
+              href="https://synergylit.reporterbase.com/contact"
+              target="_blank"
+              rel="noreferrer noopener"
+              className="mysls"
+            >
+              Access My SLS Client Portal
+            </Button>
+            <DarkModeToggle />
+          </div>
         </Navbar.Collapse>
       </Container>
     </Navbar>

--- a/src/context/ThemeContext.js
+++ b/src/context/ThemeContext.js
@@ -1,0 +1,29 @@
+import React, { createContext, useState, useEffect } from "react";
+
+export const ThemeContext = createContext();
+
+const ThemeProvider = ({ children }) => {
+  const [theme, setTheme] = useState("light");
+
+  useEffect(() => {
+    const stored = localStorage.getItem("theme");
+    const initial = stored || "light";
+    setTheme(initial);
+    document.body.setAttribute("data-bs-theme", initial);
+  }, []);
+
+  const toggleTheme = () => {
+    const next = theme === "light" ? "dark" : "light";
+    setTheme(next);
+    document.body.setAttribute("data-bs-theme", next);
+    localStorage.setItem("theme", next);
+  };
+
+  return (
+    <ThemeContext.Provider value={{ theme, toggleTheme }}>
+      {children}
+    </ThemeContext.Provider>
+  );
+};
+
+export default ThemeProvider;

--- a/src/index.js
+++ b/src/index.js
@@ -3,6 +3,7 @@ import ReactDOM from 'react-dom/client';
 import './index.css';
 import App from './App';
 import reportWebVitals from './reportWebVitals';
+import ThemeProvider from './context/ThemeContext';
 
 // *  Custom Sass File
 import "./scss/custom.scss";
@@ -10,7 +11,9 @@ import "./scss/custom.scss";
 const root = ReactDOM.createRoot(document.getElementById('root'));
 root.render(
   <React.StrictMode>
-    <App />
+    <ThemeProvider>
+      <App />
+    </ThemeProvider>
   </React.StrictMode>
 );
 


### PR DESCRIPTION
## Summary
- add ThemeContext for managing dark mode
- add toggle button in NavBar
- update site metadata and README

## Testing
- `npm test -- -u` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_683bc873f8c08324931dcb37005764a9